### PR TITLE
Add timeout settings (default to 5 minutes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,17 @@ cloud:
         storage_key: your_azure_storage_key
 ```
 
+You can set the timeout to use when making any single request. Defaults to `5m`.
+
+```yaml
+cloud:
+    azure:
+        storage:
+            account: your_azure_storage_account
+            key: your_azure_storage_key
+            timeout: 10s
+```
+
 The Azure repository supports following settings:
 
 * `container`: Container name. Defaults to `elasticsearch-snapshots`

--- a/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/storage/AzureStorageService.java
@@ -41,6 +41,7 @@ public interface AzureStorageService {
         public static final String API_IMPLEMENTATION = "cloud.azure.storage.api.impl";
         public static final String ACCOUNT = "cloud.azure.storage.account";
         public static final String KEY = "cloud.azure.storage.key";
+        public static final String TIMEOUT = "cloud.azure.storage.timeout";
         public static final String CONTAINER = "repositories.azure.container";
         public static final String BASE_PATH = "repositories.azure.base_path";
         public static final String CHUNK_SIZE = "repositories.azure.chunk_size";


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/issues/15833 , let's also look into the possibility of backport-ing the timeout setting for users on ES 1.7.x since the current workaround involves identifying a production data node that has a hung thread waiting for the Azure client call and restarting that data node to recover.

Closes #109.