### PR TITLE
Fix remove of azure files

### DIFF
--- a/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
+++ b/src/main/java/org/elasticsearch/cloud/azure/blobstore/AzureBlobContainer.java
@@ -60,6 +60,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
 
     @Override
     public boolean blobExists(String blobName) {
+        logger.trace("blobExists({})", blobName);
         try {
             return blobStore.client().blobExists(blobStore.container(), buildKey(blobName));
         } catch (URISyntaxException | StorageException e) {
@@ -70,6 +71,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
 
     @Override
     public InputStream openInput(String blobName) throws IOException {
+        logger.trace("openInput({})", blobName);
         try {
             return blobStore.client().getInputStream(blobStore.container(), buildKey(blobName));
         } catch (StorageException e) {
@@ -84,6 +86,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
 
     @Override
     public OutputStream createOutput(String blobName) throws IOException {
+        logger.trace("createOutput({})", blobName);
         try {
             return new AzureOutputStream(blobStore.client().getOutputStream(blobStore.container(), buildKey(blobName)));
         } catch (StorageException e) {
@@ -100,6 +103,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
 
     @Override
     public boolean deleteBlob(String blobName) throws IOException {
+        logger.trace("deleteBlob({})", blobName);
         try {
             blobStore.client().deleteBlob(blobStore.container(), buildKey(blobName));
             return true;
@@ -111,6 +115,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
 
     @Override
     public ImmutableMap<String, BlobMetaData> listBlobsByPrefix(@Nullable String prefix) throws IOException {
+        logger.trace("listBlobsByPrefix({})", prefix);
 
         try {
             return blobStore.client().listBlobsByPrefix(blobStore.container(), keyPath, prefix);
@@ -122,6 +127,7 @@ public class AzureBlobContainer extends AbstractBlobContainer {
 
     @Override
     public ImmutableMap<String, BlobMetaData> listBlobs() throws IOException {
+        logger.trace("listBlobs()");
         return listBlobsByPrefix(null);
     }
 

--- a/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTest.java
+++ b/src/test/java/org/elasticsearch/cloud/azure/storage/AzureStorageServiceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cloud.azure.storage;
+
+import org.elasticsearch.test.ElasticsearchTestCase;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.elasticsearch.cloud.azure.storage.AzureStorageServiceImpl.blobNameFromUri;
+import static org.hamcrest.Matchers.is;
+
+public class AzureStorageServiceTest extends ElasticsearchTestCase {
+    public void testBlobNameFromUri() throws URISyntaxException {
+        String name = blobNameFromUri(new URI("https://myservice.azure.net/container/path/to/myfile"));
+        assertThat(name, is("path/to/myfile"));
+        name = blobNameFromUri(new URI("http://myservice.azure.net/container/path/to/myfile"));
+        assertThat(name, is("path/to/myfile"));
+        name = blobNameFromUri(new URI("http://127.0.0.1/container/path/to/myfile"));
+        assertThat(name, is("path/to/myfile"));
+        name = blobNameFromUri(new URI("https://127.0.0.1/container/path/to/myfile"));
+        assertThat(name, is("path/to/myfile"));
+    }
+}


### PR DESCRIPTION
Probably when we updated Azure SDK, we introduced a regression.
Actually, we are not able to remove files anymore.

For example, if you register a new azure repository, the snapshot service tries to create a temp file and then remove it.
Removing does not work and you can see in logs:

```
[2016-05-18 11:03:24,914][WARN ][org.elasticsearch.cloud.azure.blobstore] [azure] can not remove [tests-ilmRPJ8URU-sh18yj38O6g/] in container {elasticsearch-snapshots}: The specified blob does not exist.
```

This fix deals with that. It now list all the files in a flatten mode, remove in the full URL the server and the container name.

As an example, when you are removing a blob which full name is `https://dpi24329.blob.core.windows.net/elasticsearch-snapshots/bar/test` you need to actually call Azure SDK with `bar/test` as the path, `elasticsearch-snapshots` is the container.

Related to elastic/elasticsearch#16472.
Related to elastic/elasticsearch#18436.

Backport of elastic/elasticsearch#18451 for 1.7 series